### PR TITLE
Remove encryption and simplify PDF viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # 🇨🇭 Swiss Offline ID Wallet (PWA)
 
-Diese App dient zur sicheren Offline-Speicherung und Vorschau von Schweizer Ausweisen (Pass, ID, Führerschein) als PDF-Vorschau.
+Diese App dient zur Offline-Speicherung und Vorschau von Schweizer Ausweisen (Pass, ID, Führerschein) als PDF-Vorschau.
 
 ## 🚀 Funktionen
 - PDF-Anzeige mit Thumbnails
-- AES-256-Verschlüsselung (CryptoJS)
-- Konfigurierbarer Schlüssel in `config.js`
 - Optionaler Basic-Auth-Schutz per `.htaccess`
 - Offline-fähig durch PWA-Setup
 - Vollständig lokal – keine Datenübertragung
@@ -13,9 +11,8 @@ Diese App dient zur sicheren Offline-Speicherung und Vorschau von Schweizer Ausw
 ## 🛠️ Installation (Apache)
 1. ZIP entpacken in Apache-Ordner (z.B. /var/www/html/offline-id-wallet)
 2. `.htaccess` und `.htpasswd` anlegen, um Basic Auth zu aktivieren
-3. In `config.js` denselben Schlüssel wie das Login-Passwort hinterlegen
-4. Apache starten / neu laden
-5. Aufrufen via `http://localhost/offline-id-wallet`
+3. Apache starten / neu laden
+4. Aufrufen via `http://localhost/offline-id-wallet`
 
 ## 📲 Als PWA installieren
 ### iOS: Safari > Teilen > Zum Home-Bildschirm

--- a/app.js
+++ b/app.js
@@ -1,12 +1,7 @@
-// encryptionKey is provided via config.js
 function viewPdf(type) {
-  const encrypted = localStorage.getItem(type);
-  if (!encrypted) return alert("Kein PDF vorhanden");
-  if (typeof encryptionKey === 'undefined') {
-    return alert('Verschlüsselungsschlüssel fehlt');
-  }
-  const decryptedBase64 = decryptPdf(encrypted, encryptionKey);
-  const blob = base64ToBlob(decryptedBase64, 'application/pdf');
+  const pdfBase64 = localStorage.getItem(type);
+  if (!pdfBase64) return alert("Kein PDF vorhanden");
+  const blob = base64ToBlob(pdfBase64, 'application/pdf');
   const url = URL.createObjectURL(blob);
   window.open(url);
 }

--- a/config.js
+++ b/config.js
@@ -1,4 +1,0 @@
-// Configuration file for the Offline ID Wallet
-// Encryption key used for AES operations
-// Adjust this value to change the key
-const encryptionKey = 'geheim123';

--- a/crypto.js
+++ b/crypto.js
@@ -1,8 +1,0 @@
-// CryptoJS is loaded via CDN in index.html
-function encryptPdf(pdfBase64, key) {
-  return CryptoJS.AES.encrypt(pdfBase64, key).toString();
-}
-function decryptPdf(encrypted, key) {
-  let bytes = CryptoJS.AES.decrypt(encrypted, key);
-  return bytes.toString(CryptoJS.enc.Utf8);
-}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
 <body>
   <div class="app-header">
     <h1>OFFLINE CARDS</h1>
-    <span class="lock-icon">🔒</span>
   </div>
   <div class="card-list">
     <div class="card" onclick="viewPdf('passport')">
@@ -26,9 +25,6 @@
       <span>FÜHRERSCHEIN</span>
     </div>
   </div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
-  <script src="config.js"></script>
-  <script src="crypto.js"></script>
   <script src="app.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,9 @@
-const CACHE_NAME = 'offline-id-cache-v1';
+const CACHE_NAME = 'offline-pdf-cache-v1';
 const FILES_TO_CACHE = [
   '/',
   '/index.html',
   '/style.css',
   '/app.js',
-  '/crypto.js',
-  '/config.js',
   '/manifest.json',
   '/img/passport_thumb.png',
   '/img/id_thumb.png',


### PR DESCRIPTION
## Summary
- remove encryption and configuration files
- simplify viewer to open stored PDFs directly
- update service worker and docs for offline PDF viewer

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49c96ceb0832d964c944160a521c1