### PR TITLE
Handle storage quota errors when caching PDFs on iOS

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,11 @@ async function viewPdf(type) {
       if (!response.ok) throw new Error('PDF not found');
       const blob = await response.blob();
       pdfBase64 = await blobToBase64(blob);
-      localStorage.setItem(type, pdfBase64);
+      try {
+        localStorage.setItem(type, pdfBase64);
+      } catch (storageErr) {
+        console.warn('Speicher für PDFs ist voll, lade ohne Zwischenspeicherung.', storageErr);
+      }
     } catch (err) {
       console.error(`Fehler beim Laden von ${type}.pdf`, err);
       return alert("Kein PDF vorhanden");


### PR DESCRIPTION
## Summary
- Prevent "Kein PDF" alert when saving multiple PDFs by catching localStorage quota errors.
- Gracefully skip caching when storage is full.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b54a6c40832da645b5acd8323935